### PR TITLE
Added all datatypes supported by rust-n5

### DIFF
--- a/pyn5/__init__.py
+++ b/pyn5/__init__.py
@@ -1,0 +1,82 @@
+import json
+from pathlib import Path
+import logging
+
+from .libpyn5 import (
+    DatasetUINT8,
+    DatasetUINT16,
+    DatasetUINT32,
+    DatasetUINT64,
+    DatasetINT8,
+    DatasetINT16,
+    DatasetINT32,
+    DatasetINT64,
+    DatasetFLOAT32,
+    DatasetFLOAT64,
+    create_dataset,
+)
+
+
+def open(root_path: str, dataset: str, dtype: str = "", read_only=True):
+    """
+    Returns a Dataset of the corresponding dtype. Leave dtype blank to return
+    the Dataset with dtype as shown in the attributes.json file
+    """
+
+    # Check the attributes file:
+    attributes_file = Path(root_path, dataset, "attributes.json")
+    if attributes_file.exists():
+        with attributes_file.open("r") as f:
+            attributes = json.load(f)
+        expected_dtype = attributes.get("dataType", None)
+        if expected_dtype is not None:
+            if dtype == "":
+                # Use the expected dtype
+                return open(root_path, dataset, expected_dtype.upper(), read_only)
+            elif dtype != expected_dtype.upper():
+                # When in doubt use the user specified dtype
+                logging.warning(
+                    "Given dtype {} does not match dtype ({}) in attributes.json".format(
+                        dtype, expected_dtype.upper()
+                    )
+                )
+
+    if dtype == "UINT8":
+        return DatasetUINT8(root_path, dataset, read_only)
+    elif dtype == "UINT16":
+        return DatasetUINT16(root_path, dataset, read_only)
+    elif dtype == "UINT32":
+        return DatasetUINT32(root_path, dataset, read_only)
+    elif dtype == "UINT64":
+        return DatasetUINT64(root_path, dataset, read_only)
+    elif dtype == "INT8":
+        return DatasetINT8(root_path, dataset, read_only)
+    elif dtype == "INT16":
+        return DatasetINT16(root_path, dataset, read_only)
+    elif dtype == "INT32":
+        return DatasetINT32(root_path, dataset, read_only)
+    elif dtype == "INT64":
+        return DatasetINT64(root_path, dataset, read_only)
+    elif dtype == "FLOAT32":
+        return DatasetFLOAT32(root_path, dataset, read_only)
+    elif dtype == "FLOAT64":
+        return DatasetFLOAT64(root_path, dataset, read_only)
+    else:
+        raise ValueError(
+            "Given dtype {} is not supported. Please choose from ({})".format(
+                dtype,
+                (
+                    "UINT8",
+                    "UINT16",
+                    "UINT32",
+                    "UINT64",
+                    "INT8",
+                    "INT16",
+                    "INT32",
+                    "INT64",
+                    "FLOAT32",
+                    "FLOAT64",
+                ),
+            )
+        )
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(
+    name="pyn5",
+    version="0.0.1",
+    description="Python wrapper around rust-n5 library",
+    author="William Patton",
+    license="MIT license",
+    author_email="pattonw@hhmi.org",
+    url="https://github.com/pattonw/rust-pyn5",
+)
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,27 +5,158 @@ extern crate n5;
 extern crate pyo3;
 
 use n5::prelude::*;
-use pyo3::prelude::*;
 use pyo3::exceptions;
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn create_dataset(
+    _py: Python,
+    root_path: &str,
+    path_name: &str,
+    dimensions: Vec<i64>,
+    block_size: Vec<i32>,
+    dtype: &str,
+) -> PyResult<()> {
+    let n = N5Filesystem::open_or_create(root_path).unwrap();
+    if !n.exists(path_name) {
+        match dtype {
+            "u8" => {
+                let data_attrs = DatasetAttributes::new(
+                    dimensions,
+                    block_size,
+                    DataType::UINT8,
+                    CompressionType::new::<compression::gzip::GzipCompression>(),
+                );
+                n.create_dataset(path_name, &data_attrs)?;
+                Ok(())
+            }
+            "u16" => {
+                let data_attrs = DatasetAttributes::new(
+                    dimensions,
+                    block_size,
+                    DataType::UINT16,
+                    CompressionType::new::<compression::gzip::GzipCompression>(),
+                );
+                n.create_dataset(path_name, &data_attrs)?;
+                Ok(())
+            }
+            "u32" => {
+                let data_attrs = DatasetAttributes::new(
+                    dimensions,
+                    block_size,
+                    DataType::UINT32,
+                    CompressionType::new::<compression::gzip::GzipCompression>(),
+                );
+                n.create_dataset(path_name, &data_attrs)?;
+                Ok(())
+            }
+            "u64" => {
+                let data_attrs = DatasetAttributes::new(
+                    dimensions,
+                    block_size,
+                    DataType::UINT64,
+                    CompressionType::new::<compression::gzip::GzipCompression>(),
+                );
+                n.create_dataset(path_name, &data_attrs)?;
+                Ok(())
+            }
+            "i8" => {
+                let data_attrs = DatasetAttributes::new(
+                    dimensions,
+                    block_size,
+                    DataType::INT8,
+                    CompressionType::new::<compression::gzip::GzipCompression>(),
+                );
+                n.create_dataset(path_name, &data_attrs)?;
+                Ok(())
+            }
+            "i16" => {
+                let data_attrs = DatasetAttributes::new(
+                    dimensions,
+                    block_size,
+                    DataType::INT16,
+                    CompressionType::new::<compression::gzip::GzipCompression>(),
+                );
+                n.create_dataset(path_name, &data_attrs)?;
+                Ok(())
+            }
+            "i32" => {
+                let data_attrs = DatasetAttributes::new(
+                    dimensions,
+                    block_size,
+                    DataType::INT32,
+                    CompressionType::new::<compression::gzip::GzipCompression>(),
+                );
+                n.create_dataset(path_name, &data_attrs)?;
+                Ok(())
+            }
+            "i64" => {
+                let data_attrs = DatasetAttributes::new(
+                    dimensions,
+                    block_size,
+                    DataType::INT64,
+                    CompressionType::new::<compression::gzip::GzipCompression>(),
+                );
+                n.create_dataset(path_name, &data_attrs)?;
+                Ok(())
+            }
+            "f32" => {
+                let data_attrs = DatasetAttributes::new(
+                    dimensions,
+                    block_size,
+                    DataType::FLOAT32,
+                    CompressionType::new::<compression::gzip::GzipCompression>(),
+                );
+                n.create_dataset(path_name, &data_attrs)?;
+                Ok(())
+            }
+            "f64" => {
+                let data_attrs = DatasetAttributes::new(
+                    dimensions,
+                    block_size,
+                    DataType::FLOAT64,
+                    CompressionType::new::<compression::gzip::GzipCompression>(),
+                );
+                n.create_dataset(path_name, &data_attrs)?;
+                Ok(())
+            }
+            _ => Err(exceptions::ValueError::py_err(format!(
+                "Datatype {} is not supported. Please choose from {:#?}",
+                dtype,
+                ("u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64", "f32", "f64")
+            ))),
+        }
+    } else {
+        Err(exceptions::ValueError::py_err(format!(
+            "Dataset {} already exists!",
+            path_name
+        )))
+    }
+}
 
 #[pyclass]
-struct Dataset {
+struct DatasetU8 {
     n5: N5Filesystem,
     attr: DatasetAttributes,
     path: String,
 }
 
 #[pymethods]
-impl Dataset {
+impl DatasetU8 {
     #[new]
-    fn __new__(obj: &PyRawObject, root_path: &str, path_name: &str, read_only: bool) -> PyResult<()> {
+    fn __new__(
+        obj: &PyRawObject,
+        root_path: &str,
+        path_name: &str,
+        read_only: bool,
+    ) -> PyResult<()> {
         // TODO: pass in optional attributes which can be used to create datasets rather
         // than panicing when dataset does not exist
         Ok(obj.init({
             if read_only {
                 let n = N5Filesystem::open(root_path).unwrap();
                 let attributes = n.get_dataset_attributes(path_name).unwrap();
-                Dataset {
+                Self {
                     n5: n,
                     attr: attributes,
                     path: path_name.to_string(),
@@ -33,7 +164,7 @@ impl Dataset {
             } else {
                 let n = N5Filesystem::open_or_create(root_path).unwrap();
                 let attributes = n.get_dataset_attributes(path_name).unwrap();
-                Dataset {
+                Self {
                     n5: n,
                     attr: attributes,
                     path: path_name.to_string(),
@@ -77,36 +208,685 @@ impl Dataset {
     }
 }
 
-#[pyfunction]
-fn create_dataset(
-    _py: Python,
-    root_path: &str,
-    path_name: &str,
-    dimensions: Vec<i64>,
-    block_size: Vec<i32>,
-) -> PyResult<()> {
-    let n = N5Filesystem::open_or_create(root_path).unwrap();
-    if !n.exists(path_name) {
-        let data_attrs = DatasetAttributes::new(
-            dimensions,
-            block_size,
-            DataType::UINT8,
-            CompressionType::new::<compression::gzip::GzipCompression>(),
-        );
-        n.create_dataset(path_name, &data_attrs)?;
-        Ok(())
-    } else {
-        Err(exceptions::ValueError::py_err(format!(
-            "Dataset {} already exists!",
-            path_name
-        )))
+#[pyclass]
+struct DatasetU16 {
+    n5: N5Filesystem,
+    attr: DatasetAttributes,
+    path: String,
+}
+
+#[pymethods]
+impl DatasetU16 {
+    #[new]
+    fn __new__(
+        obj: &PyRawObject,
+        root_path: &str,
+        path_name: &str,
+        read_only: bool,
+    ) -> PyResult<()> {
+        // TODO: pass in optional attributes which can be used to create datasets rather
+        // than panicing when dataset does not exist
+        Ok(obj.init({
+            if read_only {
+                let n = N5Filesystem::open(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            } else {
+                let n = N5Filesystem::open_or_create(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            }
+        }))
+    }
+
+    fn read_ndarray(&self, translation: Vec<i64>, dimensions: Vec<i64>) -> PyResult<Vec<u16>> {
+        let bounding_box = BoundingBox::new(translation, dimensions);
+
+        let block_out = self
+            .n5
+            .read_ndarray::<u16>(&self.path, &self.attr, &bounding_box)
+            .unwrap();
+        Ok(block_out.into_raw_vec())
+    }
+
+    fn write_block(&self, position: Vec<i64>, data: Vec<u16>) -> PyResult<()> {
+        let block_shape = self.attr.get_block_size().to_vec();
+        let block_size = block_shape.iter().fold(1, |a, &b| a * b) as usize;
+
+        if block_size != data.len() {
+            Err(exceptions::ValueError::py_err(format!(
+                "Data has length {} but dataset {} has blocks with shape {:?} and size {}",
+                data.len(),
+                self.path,
+                block_shape,
+                block_size
+            )))
+        } else if self.n5.exists(&self.path) {
+            let block_in = VecDataBlock::new(block_shape, position, data);
+            self.n5.write_block(&self.path, &self.attr, &block_in)?;
+            Ok(())
+        } else {
+            Err(exceptions::ValueError::py_err(format!(
+                "Dataset {} does not exist!",
+                &self.path
+            )))
+        }
+    }
+}
+
+#[pyclass]
+struct DatasetU32 {
+    n5: N5Filesystem,
+    attr: DatasetAttributes,
+    path: String,
+}
+
+#[pymethods]
+impl DatasetU32 {
+    #[new]
+    fn __new__(
+        obj: &PyRawObject,
+        root_path: &str,
+        path_name: &str,
+        read_only: bool,
+    ) -> PyResult<()> {
+        // TODO: pass in optional attributes which can be used to create datasets rather
+        // than panicing when dataset does not exist
+        Ok(obj.init({
+            if read_only {
+                let n = N5Filesystem::open(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            } else {
+                let n = N5Filesystem::open_or_create(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            }
+        }))
+    }
+
+    fn read_ndarray(&self, translation: Vec<i64>, dimensions: Vec<i64>) -> PyResult<Vec<u32>> {
+        let bounding_box = BoundingBox::new(translation, dimensions);
+
+        let block_out = self
+            .n5
+            .read_ndarray::<u32>(&self.path, &self.attr, &bounding_box)
+            .unwrap();
+        Ok(block_out.into_raw_vec())
+    }
+
+    fn write_block(&self, position: Vec<i64>, data: Vec<u32>) -> PyResult<()> {
+        let block_shape = self.attr.get_block_size().to_vec();
+        let block_size = block_shape.iter().fold(1, |a, &b| a * b) as usize;
+
+        if block_size != data.len() {
+            Err(exceptions::ValueError::py_err(format!(
+                "Data has length {} but dataset {} has blocks with shape {:?} and size {}",
+                data.len(),
+                self.path,
+                block_shape,
+                block_size
+            )))
+        } else if self.n5.exists(&self.path) {
+            let block_in = VecDataBlock::new(block_shape, position, data);
+            self.n5.write_block(&self.path, &self.attr, &block_in)?;
+            Ok(())
+        } else {
+            Err(exceptions::ValueError::py_err(format!(
+                "Dataset {} does not exist!",
+                &self.path
+            )))
+        }
+    }
+}
+
+#[pyclass]
+struct DatasetU64 {
+    n5: N5Filesystem,
+    attr: DatasetAttributes,
+    path: String,
+}
+
+#[pymethods]
+impl DatasetU64 {
+    #[new]
+    fn __new__(
+        obj: &PyRawObject,
+        root_path: &str,
+        path_name: &str,
+        read_only: bool,
+    ) -> PyResult<()> {
+        // TODO: pass in optional attributes which can be used to create datasets rather
+        // than panicing when dataset does not exist
+        Ok(obj.init({
+            if read_only {
+                let n = N5Filesystem::open(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            } else {
+                let n = N5Filesystem::open_or_create(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            }
+        }))
+    }
+
+    fn read_ndarray(&self, translation: Vec<i64>, dimensions: Vec<i64>) -> PyResult<Vec<u64>> {
+        let bounding_box = BoundingBox::new(translation, dimensions);
+
+        let block_out = self
+            .n5
+            .read_ndarray::<u64>(&self.path, &self.attr, &bounding_box)
+            .unwrap();
+        Ok(block_out.into_raw_vec())
+    }
+
+    fn write_block(&self, position: Vec<i64>, data: Vec<u64>) -> PyResult<()> {
+        let block_shape = self.attr.get_block_size().to_vec();
+        let block_size = block_shape.iter().fold(1, |a, &b| a * b) as usize;
+
+        if block_size != data.len() {
+            Err(exceptions::ValueError::py_err(format!(
+                "Data has length {} but dataset {} has blocks with shape {:?} and size {}",
+                data.len(),
+                self.path,
+                block_shape,
+                block_size
+            )))
+        } else if self.n5.exists(&self.path) {
+            let block_in = VecDataBlock::new(block_shape, position, data);
+            self.n5.write_block(&self.path, &self.attr, &block_in)?;
+            Ok(())
+        } else {
+            Err(exceptions::ValueError::py_err(format!(
+                "Dataset {} does not exist!",
+                &self.path
+            )))
+        }
+    }
+}
+
+#[pyclass]
+struct DatasetI8 {
+    n5: N5Filesystem,
+    attr: DatasetAttributes,
+    path: String,
+}
+
+#[pymethods]
+impl DatasetI8 {
+    #[new]
+    fn __new__(
+        obj: &PyRawObject,
+        root_path: &str,
+        path_name: &str,
+        read_only: bool,
+    ) -> PyResult<()> {
+        // TODO: pass in optional attributes which can be used to create datasets rather
+        // than panicing when dataset does not exist
+        Ok(obj.init({
+            if read_only {
+                let n = N5Filesystem::open(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            } else {
+                let n = N5Filesystem::open_or_create(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            }
+        }))
+    }
+
+    fn read_ndarray(&self, translation: Vec<i64>, dimensions: Vec<i64>) -> PyResult<Vec<i8>> {
+        let bounding_box = BoundingBox::new(translation, dimensions);
+
+        let block_out = self
+            .n5
+            .read_ndarray::<i8>(&self.path, &self.attr, &bounding_box)
+            .unwrap();
+        Ok(block_out.into_raw_vec())
+    }
+
+    fn write_block(&self, position: Vec<i64>, data: Vec<i8>) -> PyResult<()> {
+        let block_shape = self.attr.get_block_size().to_vec();
+        let block_size = block_shape.iter().fold(1, |a, &b| a * b) as usize;
+
+        if block_size != data.len() {
+            Err(exceptions::ValueError::py_err(format!(
+                "Data has length {} but dataset {} has blocks with shape {:?} and size {}",
+                data.len(),
+                self.path,
+                block_shape,
+                block_size
+            )))
+        } else if self.n5.exists(&self.path) {
+            let block_in = VecDataBlock::new(block_shape, position, data);
+            self.n5.write_block(&self.path, &self.attr, &block_in)?;
+            Ok(())
+        } else {
+            Err(exceptions::ValueError::py_err(format!(
+                "Dataset {} does not exist!",
+                &self.path
+            )))
+        }
+    }
+}
+
+#[pyclass]
+struct DatasetI16 {
+    n5: N5Filesystem,
+    attr: DatasetAttributes,
+    path: String,
+}
+
+#[pymethods]
+impl DatasetI16 {
+    #[new]
+    fn __new__(
+        obj: &PyRawObject,
+        root_path: &str,
+        path_name: &str,
+        read_only: bool,
+    ) -> PyResult<()> {
+        // TODO: pass in optional attributes which can be used to create datasets rather
+        // than panicing when dataset does not exist
+        Ok(obj.init({
+            if read_only {
+                let n = N5Filesystem::open(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            } else {
+                let n = N5Filesystem::open_or_create(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            }
+        }))
+    }
+
+    fn read_ndarray(&self, translation: Vec<i64>, dimensions: Vec<i64>) -> PyResult<Vec<i16>> {
+        let bounding_box = BoundingBox::new(translation, dimensions);
+
+        let block_out = self
+            .n5
+            .read_ndarray::<i16>(&self.path, &self.attr, &bounding_box)
+            .unwrap();
+        Ok(block_out.into_raw_vec())
+    }
+
+    fn write_block(&self, position: Vec<i64>, data: Vec<i16>) -> PyResult<()> {
+        let block_shape = self.attr.get_block_size().to_vec();
+        let block_size = block_shape.iter().fold(1, |a, &b| a * b) as usize;
+
+        if block_size != data.len() {
+            Err(exceptions::ValueError::py_err(format!(
+                "Data has length {} but dataset {} has blocks with shape {:?} and size {}",
+                data.len(),
+                self.path,
+                block_shape,
+                block_size
+            )))
+        } else if self.n5.exists(&self.path) {
+            let block_in = VecDataBlock::new(block_shape, position, data);
+            self.n5.write_block(&self.path, &self.attr, &block_in)?;
+            Ok(())
+        } else {
+            Err(exceptions::ValueError::py_err(format!(
+                "Dataset {} does not exist!",
+                &self.path
+            )))
+        }
+    }
+}
+
+#[pyclass]
+struct DatasetI32 {
+    n5: N5Filesystem,
+    attr: DatasetAttributes,
+    path: String,
+}
+
+#[pymethods]
+impl DatasetI32 {
+    #[new]
+    fn __new__(
+        obj: &PyRawObject,
+        root_path: &str,
+        path_name: &str,
+        read_only: bool,
+    ) -> PyResult<()> {
+        // TODO: pass in optional attributes which can be used to create datasets rather
+        // than panicing when dataset does not exist
+        Ok(obj.init({
+            if read_only {
+                let n = N5Filesystem::open(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            } else {
+                let n = N5Filesystem::open_or_create(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            }
+        }))
+    }
+
+    fn read_ndarray(&self, translation: Vec<i64>, dimensions: Vec<i64>) -> PyResult<Vec<i32>> {
+        let bounding_box = BoundingBox::new(translation, dimensions);
+
+        let block_out = self
+            .n5
+            .read_ndarray::<i32>(&self.path, &self.attr, &bounding_box)
+            .unwrap();
+        Ok(block_out.into_raw_vec())
+    }
+
+    fn write_block(&self, position: Vec<i64>, data: Vec<i32>) -> PyResult<()> {
+        let block_shape = self.attr.get_block_size().to_vec();
+        let block_size = block_shape.iter().fold(1, |a, &b| a * b) as usize;
+
+        if block_size != data.len() {
+            Err(exceptions::ValueError::py_err(format!(
+                "Data has length {} but dataset {} has blocks with shape {:?} and size {}",
+                data.len(),
+                self.path,
+                block_shape,
+                block_size
+            )))
+        } else if self.n5.exists(&self.path) {
+            let block_in = VecDataBlock::new(block_shape, position, data);
+            self.n5.write_block(&self.path, &self.attr, &block_in)?;
+            Ok(())
+        } else {
+            Err(exceptions::ValueError::py_err(format!(
+                "Dataset {} does not exist!",
+                &self.path
+            )))
+        }
+    }
+}
+
+#[pyclass]
+struct DatasetI64 {
+    n5: N5Filesystem,
+    attr: DatasetAttributes,
+    path: String,
+}
+
+#[pymethods]
+impl DatasetI64 {
+    #[new]
+    fn __new__(
+        obj: &PyRawObject,
+        root_path: &str,
+        path_name: &str,
+        read_only: bool,
+    ) -> PyResult<()> {
+        // TODO: pass in optional attributes which can be used to create datasets rather
+        // than panicing when dataset does not exist
+        Ok(obj.init({
+            if read_only {
+                let n = N5Filesystem::open(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            } else {
+                let n = N5Filesystem::open_or_create(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            }
+        }))
+    }
+
+    fn read_ndarray(&self, translation: Vec<i64>, dimensions: Vec<i64>) -> PyResult<Vec<i64>> {
+        let bounding_box = BoundingBox::new(translation, dimensions);
+
+        let block_out = self
+            .n5
+            .read_ndarray::<i64>(&self.path, &self.attr, &bounding_box)
+            .unwrap();
+        Ok(block_out.into_raw_vec())
+    }
+
+    fn write_block(&self, position: Vec<i64>, data: Vec<i64>) -> PyResult<()> {
+        let block_shape = self.attr.get_block_size().to_vec();
+        let block_size = block_shape.iter().fold(1, |a, &b| a * b) as usize;
+
+        if block_size != data.len() {
+            Err(exceptions::ValueError::py_err(format!(
+                "Data has length {} but dataset {} has blocks with shape {:?} and size {}",
+                data.len(),
+                self.path,
+                block_shape,
+                block_size
+            )))
+        } else if self.n5.exists(&self.path) {
+            let block_in = VecDataBlock::new(block_shape, position, data);
+            self.n5.write_block(&self.path, &self.attr, &block_in)?;
+            Ok(())
+        } else {
+            Err(exceptions::ValueError::py_err(format!(
+                "Dataset {} does not exist!",
+                &self.path
+            )))
+        }
+    }
+}
+
+#[pyclass]
+struct DatasetF32 {
+    n5: N5Filesystem,
+    attr: DatasetAttributes,
+    path: String,
+}
+
+#[pymethods]
+impl DatasetF32 {
+    #[new]
+    fn __new__(
+        obj: &PyRawObject,
+        root_path: &str,
+        path_name: &str,
+        read_only: bool,
+    ) -> PyResult<()> {
+        // TODO: pass in optional attributes which can be used to create datasets rather
+        // than panicing when dataset does not exist
+        Ok(obj.init({
+            if read_only {
+                let n = N5Filesystem::open(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            } else {
+                let n = N5Filesystem::open_or_create(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            }
+        }))
+    }
+
+    fn read_ndarray(&self, translation: Vec<i64>, dimensions: Vec<i64>) -> PyResult<Vec<f32>> {
+        let bounding_box = BoundingBox::new(translation, dimensions);
+
+        let block_out = self
+            .n5
+            .read_ndarray::<f32>(&self.path, &self.attr, &bounding_box)
+            .unwrap();
+        Ok(block_out.into_raw_vec())
+    }
+
+    fn write_block(&self, position: Vec<i64>, data: Vec<f32>) -> PyResult<()> {
+        let block_shape = self.attr.get_block_size().to_vec();
+        let block_size = block_shape.iter().fold(1, |a, &b| a * b) as usize;
+
+        if block_size != data.len() {
+            Err(exceptions::ValueError::py_err(format!(
+                "Data has length {} but dataset {} has blocks with shape {:?} and size {}",
+                data.len(),
+                self.path,
+                block_shape,
+                block_size
+            )))
+        } else if self.n5.exists(&self.path) {
+            let block_in = VecDataBlock::new(block_shape, position, data);
+            self.n5.write_block(&self.path, &self.attr, &block_in)?;
+            Ok(())
+        } else {
+            Err(exceptions::ValueError::py_err(format!(
+                "Dataset {} does not exist!",
+                &self.path
+            )))
+        }
+    }
+}
+
+#[pyclass]
+struct DatasetF64 {
+    n5: N5Filesystem,
+    attr: DatasetAttributes,
+    path: String,
+}
+
+#[pymethods]
+impl DatasetF64 {
+    #[new]
+    fn __new__(
+        obj: &PyRawObject,
+        root_path: &str,
+        path_name: &str,
+        read_only: bool,
+    ) -> PyResult<()> {
+        // TODO: pass in optional attributes which can be used to create datasets rather
+        // than panicing when dataset does not exist
+        Ok(obj.init({
+            if read_only {
+                let n = N5Filesystem::open(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            } else {
+                let n = N5Filesystem::open_or_create(root_path).unwrap();
+                let attributes = n.get_dataset_attributes(path_name).unwrap();
+                Self {
+                    n5: n,
+                    attr: attributes,
+                    path: path_name.to_string(),
+                }
+            }
+        }))
+    }
+
+    fn read_ndarray(&self, translation: Vec<i64>, dimensions: Vec<i64>) -> PyResult<Vec<f64>> {
+        let bounding_box = BoundingBox::new(translation, dimensions);
+
+        let block_out = self
+            .n5
+            .read_ndarray::<f64>(&self.path, &self.attr, &bounding_box)
+            .unwrap();
+        Ok(block_out.into_raw_vec())
+    }
+
+    fn write_block(&self, position: Vec<i64>, data: Vec<f64>) -> PyResult<()> {
+        let block_shape = self.attr.get_block_size().to_vec();
+        let block_size = block_shape.iter().fold(1, |a, &b| a * b) as usize;
+
+        if block_size != data.len() {
+            Err(exceptions::ValueError::py_err(format!(
+                "Data has length {} but dataset {} has blocks with shape {:?} and size {}",
+                data.len(),
+                self.path,
+                block_shape,
+                block_size
+            )))
+        } else if self.n5.exists(&self.path) {
+            let block_in = VecDataBlock::new(block_shape, position, data);
+            self.n5.write_block(&self.path, &self.attr, &block_in)?;
+            Ok(())
+        } else {
+            Err(exceptions::ValueError::py_err(format!(
+                "Dataset {} does not exist!",
+                &self.path
+            )))
+        }
     }
 }
 
 #[pymodule]
 fn libpyn5(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(create_dataset))?;
-    m.add_class::<Dataset>()?;
+    m.add_class::<DatasetU8>()?;
+    m.add_class::<DatasetU16>()?;
+    m.add_class::<DatasetU32>()?;
+    m.add_class::<DatasetU64>()?;
+    m.add_class::<DatasetI8>()?;
+    m.add_class::<DatasetI16>()?;
+    m.add_class::<DatasetI32>()?;
+    m.add_class::<DatasetI64>()?;
+    m.add_class::<DatasetF32>()?;
+    m.add_class::<DatasetF64>()?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,30 +217,30 @@ macro_rules! dataset {
     };
 }
 
-dataset!(DatasetU8, UINT8, u8);
-dataset!(DatasetU16, UINT16, u16);
-dataset!(DatasetU32, UINT32, u32);
-dataset!(DatasetU64, UINT64, u64);
-dataset!(DatasetI8, INT8, i8);
-dataset!(DatasetI16, INT16, i16);
-dataset!(DatasetI32, INT32, i32);
-dataset!(DatasetI64, INT64, i64);
-dataset!(DatasetF32, FLOAT32, f32);
-dataset!(DatasetF64, FLOAT64, f64);
+dataset!(DatasetUINT8, UINT8, u8);
+dataset!(DatasetUINT16, UINT16, u16);
+dataset!(DatasetUINT32, UINT32, u32);
+dataset!(DatasetUINT64, UINT64, u64);
+dataset!(DatasetINT8, INT8, i8);
+dataset!(DatasetINT16, INT16, i16);
+dataset!(DatasetINT32, INT32, i32);
+dataset!(DatasetINT64, INT64, i64);
+dataset!(DatasetFLOAT32, FLOAT32, f32);
+dataset!(DatasetFLOAT64, FLOAT64, f64);
 
 #[pymodule]
 fn libpyn5(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(create_dataset))?;
-    m.add_class::<DatasetU8>()?;
-    m.add_class::<DatasetU16>()?;
-    m.add_class::<DatasetU32>()?;
-    m.add_class::<DatasetU64>()?;
-    m.add_class::<DatasetI8>()?;
-    m.add_class::<DatasetI16>()?;
-    m.add_class::<DatasetI32>()?;
-    m.add_class::<DatasetI64>()?;
-    m.add_class::<DatasetF32>()?;
-    m.add_class::<DatasetF64>()?;
+    m.add_class::<DatasetUINT8>()?;
+    m.add_class::<DatasetUINT16>()?;
+    m.add_class::<DatasetUINT32>()?;
+    m.add_class::<DatasetUINT64>()?;
+    m.add_class::<DatasetINT8>()?;
+    m.add_class::<DatasetINT16>()?;
+    m.add_class::<DatasetINT32>()?;
+    m.add_class::<DatasetINT64>()?;
+    m.add_class::<DatasetFLOAT32>()?;
+    m.add_class::<DatasetFLOAT64>()?;
 
     Ok(())
 }

--- a/test.py
+++ b/test.py
@@ -13,12 +13,12 @@ class TestU8(unittest.TestCase):
         self.dataset = "test_u8"
         self.dataset_size = [10, 10, 10]
         self.block_size = [2, 2, 2]
-        self.dtype = "u8"
+        self.dtype = "UINT8"
 
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetU8(self.root, self.dataset, False)
+        self.n5 = pyn5.DatasetUINT8(self.root, self.dataset, False)
 
         big = 2 ** 8
         self.working_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
@@ -67,12 +67,12 @@ class TestU16(unittest.TestCase):
         self.dataset = "test_u16"
         self.dataset_size = [10, 10, 10]
         self.block_size = [2, 2, 2]
-        self.dtype = "u16"
+        self.dtype = "UINT16"
 
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetU16(self.root, self.dataset, False)
+        self.n5 = pyn5.DatasetUINT16(self.root, self.dataset, False)
 
         big = 2 ** 16
         self.working_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
@@ -118,7 +118,7 @@ class TestU16(unittest.TestCase):
 class TestU32(unittest.TestCase):
     def setUp(self):
         self.root = "test.n5"
-        self.dtype = "u32"
+        self.dtype = "UINT32"
         self.dataset = "test_{}".format(self.dtype)
         self.dataset_size = [10, 10, 10]
         self.block_size = [2, 2, 2]
@@ -126,7 +126,7 @@ class TestU32(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetU32(self.root, self.dataset, False)
+        self.n5 = pyn5.DatasetUINT32(self.root, self.dataset, False)
 
         big = 2 ** 32
         self.working_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
@@ -172,7 +172,7 @@ class TestU32(unittest.TestCase):
 class TestU64(unittest.TestCase):
     def setUp(self):
         self.root = "test.n5"
-        self.dtype = "u64"
+        self.dtype = "UINT64"
         self.dataset = "test_{}".format(self.dtype)
         self.dataset_size = [10, 10, 10]
         self.block_size = [2, 2, 2]
@@ -180,7 +180,7 @@ class TestU64(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetU64(self.root, self.dataset, False)
+        self.n5 = pyn5.DatasetUINT64(self.root, self.dataset, False)
 
         big = 2 ** 64
         self.working_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
@@ -226,7 +226,7 @@ class TestU64(unittest.TestCase):
 class TestI8(unittest.TestCase):
     def setUp(self):
         self.root = "test.n5"
-        self.dtype = "i8"
+        self.dtype = "INT8"
         self.dataset = "test_{}".format(self.dtype)
         self.dataset_size = [10, 10, 10]
         self.block_size = [2, 2, 2]
@@ -234,7 +234,7 @@ class TestI8(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetI8(self.root, self.dataset, False)
+        self.n5 = pyn5.DatasetINT8(self.root, self.dataset, False)
 
         big = 2 ** 7
         self.working_block = [
@@ -298,7 +298,7 @@ class TestI8(unittest.TestCase):
 class TestI16(unittest.TestCase):
     def setUp(self):
         self.root = "test.n5"
-        self.dtype = "i16"
+        self.dtype = "INT16"
         self.dataset = "test_{}".format(self.dtype)
         self.dataset_size = [10, 10, 10]
         self.block_size = [2, 2, 2]
@@ -306,7 +306,7 @@ class TestI16(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetI16(self.root, self.dataset, False)
+        self.n5 = pyn5.DatasetINT16(self.root, self.dataset, False)
 
         big = 2 ** 15
         self.working_block = [
@@ -370,7 +370,7 @@ class TestI16(unittest.TestCase):
 class TestI32(unittest.TestCase):
     def setUp(self):
         self.root = "test.n5"
-        self.dtype = "i32"
+        self.dtype = "INT32"
         self.dataset = "test_{}".format(self.dtype)
         self.dataset_size = [10, 10, 10]
         self.block_size = [2, 2, 2]
@@ -378,7 +378,7 @@ class TestI32(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetI32(self.root, self.dataset, False)
+        self.n5 = pyn5.DatasetINT32(self.root, self.dataset, False)
 
         big = 2 ** 31
         self.working_block = [
@@ -442,7 +442,7 @@ class TestI32(unittest.TestCase):
 class TestI64(unittest.TestCase):
     def setUp(self):
         self.root = "test.n5"
-        self.dtype = "i64"
+        self.dtype = "INT64"
         self.dataset = "test_{}".format(self.dtype)
         self.dataset_size = [10, 10, 10]
         self.block_size = [2, 2, 2]
@@ -450,7 +450,7 @@ class TestI64(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetI64(self.root, self.dataset, False)
+        self.n5 = pyn5.DatasetINT64(self.root, self.dataset, False)
 
         big = 2 ** 63
         self.working_block = [
@@ -514,7 +514,7 @@ class TestI64(unittest.TestCase):
 class TestF32(unittest.TestCase):
     def setUp(self):
         self.root = "test.n5"
-        self.dtype = "f32"
+        self.dtype = "FLOAT32"
         self.dataset = "test_{}".format(self.dtype)
         self.dataset_size = [10, 10, 10]
         self.block_size = [2, 2, 2]
@@ -522,7 +522,7 @@ class TestF32(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetF32(self.root, self.dataset, False)
+        self.n5 = pyn5.DatasetFLOAT32(self.root, self.dataset, False)
 
         self.working_block = [
             -3.3999999521443642e38,
@@ -571,7 +571,7 @@ class TestF32(unittest.TestCase):
 class TestF64(unittest.TestCase):
     def setUp(self):
         self.root = "test.n5"
-        self.dtype = "f64"
+        self.dtype = "FLOAT64"
         self.dataset = "test_{}".format(self.dtype)
         self.dataset_size = [10, 10, 10]
         self.block_size = [2, 2, 2]
@@ -579,7 +579,7 @@ class TestF64(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetF64(self.root, self.dataset, False)
+        self.n5 = pyn5.DatasetFLOAT64(self.root, self.dataset, False)
 
         self.working_block = [
             -2.3e-308,

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,8 +3,7 @@ import shutil
 import unittest
 import numpy as np
 
-
-import target.debug.libpyn5 as pyn5
+import pyn5
 
 
 class TestU8(unittest.TestCase):
@@ -18,7 +17,7 @@ class TestU8(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetUINT8(self.root, self.dataset, False)
+        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 8
         self.working_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
@@ -60,6 +59,14 @@ class TestU8(unittest.TestCase):
                 [0] * np.prod(self.block_size),
             )
 
+    def test_writting_wrong_dtype(self):
+        bad_n5 = pyn5.open(self.root, self.dataset, "FLOAT64")
+        try:
+            bad_n5.write_block([0, 0, 0], [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
+            self.fail("Expected TypeError")
+        except TypeError:
+            pass
+
 
 class TestU16(unittest.TestCase):
     def setUp(self):
@@ -72,7 +79,7 @@ class TestU16(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetUINT16(self.root, self.dataset, False)
+        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 16
         self.working_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
@@ -126,7 +133,7 @@ class TestU32(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetUINT32(self.root, self.dataset, False)
+        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 32
         self.working_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
@@ -180,7 +187,7 @@ class TestU64(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetUINT64(self.root, self.dataset, False)
+        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 64
         self.working_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
@@ -234,7 +241,7 @@ class TestI8(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetINT8(self.root, self.dataset, False)
+        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 7
         self.working_block = [
@@ -306,7 +313,7 @@ class TestI16(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetINT16(self.root, self.dataset, False)
+        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 15
         self.working_block = [
@@ -378,7 +385,7 @@ class TestI32(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetINT32(self.root, self.dataset, False)
+        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 31
         self.working_block = [
@@ -450,7 +457,7 @@ class TestI64(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetINT64(self.root, self.dataset, False)
+        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 63
         self.working_block = [
@@ -522,7 +529,7 @@ class TestF32(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetFLOAT32(self.root, self.dataset, False)
+        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         self.working_block = [
             -3.3999999521443642e38,
@@ -579,7 +586,7 @@ class TestF64(unittest.TestCase):
         pyn5.create_dataset(
             self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
         )
-        self.n5 = pyn5.DatasetFLOAT64(self.root, self.dataset, False)
+        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         self.working_block = [
             -2.3e-308,

--- a/tests/test.py
+++ b/tests/test.py
@@ -6,58 +6,56 @@ import numpy as np
 import pyn5
 
 
-class TestU8(unittest.TestCase):
+class BaseTestCase:
+    class IntBaseTest(unittest.TestCase):
+        def setUp(self):
+            self.root = "test.n5"
+            self.dataset = "test_{}".format(self.dtype)
+            self.dataset_size = [10, 10, 10]
+            self.block_size = [2, 2, 2]
+
+            pyn5.create_dataset(
+                self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
+            )
+            self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
+
+        def tearDown(self):
+            if Path(self.root, self.dataset).is_dir():
+                shutil.rmtree(Path(self.root, self.dataset))
+
+        def test_read_write_valid(self):
+            self.n5.write_block([0, 0, 0], self.valid_block)
+            self.assertEqual(
+                self.n5.read_ndarray([0, 0, 0], self.block_size), self.valid_block
+            )
+
+        @unittest.expectedFailure
+        def test_read_write_overflow(self):
+            """
+            Doesn't work properly for float types since floats that are too
+            large get converted to inf
+            """
+            self.n5.write_block([1, 1, 1], self.overflow_block)
+
+        @unittest.expectedFailure
+        def test_read_write_wrong_dtype(self):
+            """
+            Doesn't work properly for float types since I'm guessing ints
+            get converted to float types somewhere between python and rust
+            """
+            self.n5.write_block([2, 2, 2], self.wrong_dtype_block)
+
+
+class TestU8(BaseTestCase.BaseTest):
     def setUp(self):
-        self.root = "test.n5"
-        self.dataset = "test_u8"
-        self.dataset_size = [10, 10, 10]
-        self.block_size = [2, 2, 2]
         self.dtype = "UINT8"
 
-        pyn5.create_dataset(
-            self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
-        )
-        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
-
         big = 2 ** 8
-        self.working_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
-        self.out_of_bounds_block = [-1, -2, -3, -4, big, big + 1, big + 2, big + 3]
-        self.wrong_dtype = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        self.valid_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
+        self.overflow_block = [-1, -2, -3, -4, big, big + 1, big + 2, big + 3]
+        self.wrong_dtype_block = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
 
-    def tearDown(self):
-        if Path(self.root, self.dataset).is_dir():
-            shutil.rmtree(Path(self.root, self.dataset))
-
-    def test_read_write(self):
-        # Dataset should start empty
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.dataset_size),
-            [0] * np.prod(self.dataset_size),
-        )
-        # Test writing a valid block
-        self.n5.write_block([0, 0, 0], self.working_block)
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.block_size), self.working_block
-        )
-
-        # Test writing overflow block
-        try:
-            self.n5.write_block([1, 1, 1], self.out_of_bounds_block)
-            raise AssertionError("Expected OverflowError")
-        except OverflowError:
-            self.assertEqual(
-                self.n5.read_ndarray([2, 2, 2], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
-        # Test writing invalid type block
-        try:
-            self.n5.write_block([2, 2, 2], self.wrong_dtype)
-            raise AssertionError("Expected TypeError")
-        except TypeError:
-            self.assertEqual(
-                self.n5.read_ndarray([4, 4, 4], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
+        super().setUp()
 
     def test_writting_wrong_dtype(self):
         bad_n5 = pyn5.open(self.root, self.dataset, "FLOAT64")
@@ -68,183 +66,48 @@ class TestU8(unittest.TestCase):
             pass
 
 
-class TestU16(unittest.TestCase):
+class TestU16(BaseTestCase.BaseTest):
     def setUp(self):
-        self.root = "test.n5"
-        self.dataset = "test_u16"
-        self.dataset_size = [10, 10, 10]
-        self.block_size = [2, 2, 2]
         self.dtype = "UINT16"
 
-        pyn5.create_dataset(
-            self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
-        )
-        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
-
         big = 2 ** 16
-        self.working_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
-        self.out_of_bounds_block = [-1, -2, -3, -4, big, big + 1, big + 2, big + 3]
-        self.wrong_dtype = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        self.valid_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
+        self.overflow_block = [-1, -2, -3, -4, big, big + 1, big + 2, big + 3]
+        self.wrong_dtype_block = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
 
-    def tearDown(self):
-        if Path(self.root, self.dataset).is_dir():
-            shutil.rmtree(Path(self.root, self.dataset))
-
-    def test_read_write(self):
-        # Dataset should start empty
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.dataset_size),
-            [0] * np.prod(self.dataset_size),
-        )
-        # Test writing a valid block
-        self.n5.write_block([0, 0, 0], self.working_block)
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.block_size), self.working_block
-        )
-
-        # Test writing overflow block
-        try:
-            self.n5.write_block([1, 1, 1], self.out_of_bounds_block)
-            raise AssertionError("Expected OverflowError")
-        except OverflowError:
-            self.assertEqual(
-                self.n5.read_ndarray([2, 2, 2], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
-        # Test writing invalid type block
-        try:
-            self.n5.write_block([2, 2, 2], self.wrong_dtype)
-            raise AssertionError("Expected TypeError")
-        except TypeError:
-            self.assertEqual(
-                self.n5.read_ndarray([4, 4, 4], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
+        super().setUp()
 
 
-class TestU32(unittest.TestCase):
+class TestU32(BaseTestCase.BaseTest):
     def setUp(self):
-        self.root = "test.n5"
         self.dtype = "UINT32"
-        self.dataset = "test_{}".format(self.dtype)
-        self.dataset_size = [10, 10, 10]
-        self.block_size = [2, 2, 2]
-
-        pyn5.create_dataset(
-            self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
-        )
-        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 32
-        self.working_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
-        self.out_of_bounds_block = [-1, -2, -3, -4, big, big + 1, big + 2, big + 3]
-        self.wrong_dtype = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        self.valid_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
+        self.overflow_block = [-1, -2, -3, -4, big, big + 1, big + 2, big + 3]
+        self.wrong_dtype_block = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
 
-    def tearDown(self):
-        if Path(self.root, self.dataset).is_dir():
-            shutil.rmtree(Path(self.root, self.dataset))
-
-    def test_read_write(self):
-        # Dataset should start empty
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.dataset_size),
-            [0] * np.prod(self.dataset_size),
-        )
-        # Test writing a valid block
-        self.n5.write_block([0, 0, 0], self.working_block)
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.block_size), self.working_block
-        )
-
-        # Test writing overflow block
-        try:
-            self.n5.write_block([1, 1, 1], self.out_of_bounds_block)
-            raise AssertionError("Expected OverflowError")
-        except OverflowError:
-            self.assertEqual(
-                self.n5.read_ndarray([2, 2, 2], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
-        # Test writing invalid type block
-        try:
-            self.n5.write_block([2, 2, 2], self.wrong_dtype)
-            raise AssertionError("Expected TypeError")
-        except TypeError:
-            self.assertEqual(
-                self.n5.read_ndarray([4, 4, 4], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
+        super().setUp()
 
 
-class TestU64(unittest.TestCase):
+class TestU64(BaseTestCase.BaseTest):
     def setUp(self):
-        self.root = "test.n5"
         self.dtype = "UINT64"
-        self.dataset = "test_{}".format(self.dtype)
-        self.dataset_size = [10, 10, 10]
-        self.block_size = [2, 2, 2]
-
-        pyn5.create_dataset(
-            self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
-        )
-        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 64
-        self.working_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
-        self.out_of_bounds_block = [-1, -2, -3, -4, big, big + 1, big + 2, big + 3]
-        self.wrong_dtype = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        self.valid_block = [0, 1, 2, 3, big - 4, big - 3, big - 2, big - 1]
+        self.overflow_block = [-1, -2, -3, -4, big, big + 1, big + 2, big + 3]
+        self.wrong_dtype_block = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
 
-    def tearDown(self):
-        if Path(self.root, self.dataset).is_dir():
-            shutil.rmtree(Path(self.root, self.dataset))
-
-    def test_read_write(self):
-        # Dataset should start empty
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.dataset_size),
-            [0] * np.prod(self.dataset_size),
-        )
-        # Test writing a valid block
-        self.n5.write_block([0, 0, 0], self.working_block)
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.block_size), self.working_block
-        )
-
-        # Test writing overflow block
-        try:
-            self.n5.write_block([1, 1, 1], self.out_of_bounds_block)
-            raise AssertionError("Expected OverflowError")
-        except OverflowError:
-            self.assertEqual(
-                self.n5.read_ndarray([2, 2, 2], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
-        # Test writing invalid type block
-        try:
-            self.n5.write_block([2, 2, 2], self.wrong_dtype)
-            raise AssertionError("Expected TypeError")
-        except TypeError:
-            self.assertEqual(
-                self.n5.read_ndarray([4, 4, 4], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
+        super().setUp()
 
 
-class TestI8(unittest.TestCase):
+class TestI8(BaseTestCase.BaseTest):
     def setUp(self):
-        self.root = "test.n5"
         self.dtype = "INT8"
-        self.dataset = "test_{}".format(self.dtype)
-        self.dataset_size = [10, 10, 10]
-        self.block_size = [2, 2, 2]
-
-        pyn5.create_dataset(
-            self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
-        )
-        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 7
-        self.working_block = [
+        self.valid_block = [
             1 - big,
             2 - big,
             3 - big,
@@ -254,7 +117,7 @@ class TestI8(unittest.TestCase):
             big - 2,
             big - 1,
         ]
-        self.out_of_bounds_block = [
+        self.overflow_block = [
             -big,
             -1 - big,
             -2 - big,
@@ -264,59 +127,17 @@ class TestI8(unittest.TestCase):
             big + 2,
             big + 3,
         ]
-        self.wrong_dtype = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        self.wrong_dtype_block = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
 
-    def tearDown(self):
-        if Path(self.root, self.dataset).is_dir():
-            shutil.rmtree(Path(self.root, self.dataset))
-
-    def test_read_write(self):
-        # Dataset should start empty
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.dataset_size),
-            [0] * np.prod(self.dataset_size),
-        )
-        # Test writing a valid block
-        self.n5.write_block([0, 0, 0], self.working_block)
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.block_size), self.working_block
-        )
-
-        # Test writing overflow block
-        try:
-            self.n5.write_block([1, 1, 1], self.out_of_bounds_block)
-            raise AssertionError("Expected OverflowError")
-        except OverflowError:
-            self.assertEqual(
-                self.n5.read_ndarray([2, 2, 2], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
-        # Test writing invalid type block
-        try:
-            self.n5.write_block([2, 2, 2], self.wrong_dtype)
-            raise AssertionError("Expected TypeError")
-        except TypeError:
-            self.assertEqual(
-                self.n5.read_ndarray([4, 4, 4], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
+        super().setUp()
 
 
-class TestI16(unittest.TestCase):
+class TestI16(BaseTestCase.BaseTest):
     def setUp(self):
-        self.root = "test.n5"
         self.dtype = "INT16"
-        self.dataset = "test_{}".format(self.dtype)
-        self.dataset_size = [10, 10, 10]
-        self.block_size = [2, 2, 2]
-
-        pyn5.create_dataset(
-            self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
-        )
-        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 15
-        self.working_block = [
+        self.valid_block = [
             1 - big,
             2 - big,
             3 - big,
@@ -326,7 +147,7 @@ class TestI16(unittest.TestCase):
             big - 2,
             big - 1,
         ]
-        self.out_of_bounds_block = [
+        self.overflow_block = [
             -big,
             -1 - big,
             -2 - big,
@@ -336,59 +157,17 @@ class TestI16(unittest.TestCase):
             big + 2,
             big + 3,
         ]
-        self.wrong_dtype = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        self.wrong_dtype_block = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
 
-    def tearDown(self):
-        if Path(self.root, self.dataset).is_dir():
-            shutil.rmtree(Path(self.root, self.dataset))
-
-    def test_read_write(self):
-        # Dataset should start empty
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.dataset_size),
-            [0] * np.prod(self.dataset_size),
-        )
-        # Test writing a valid block
-        self.n5.write_block([0, 0, 0], self.working_block)
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.block_size), self.working_block
-        )
-
-        # Test writing overflow block
-        try:
-            self.n5.write_block([1, 1, 1], self.out_of_bounds_block)
-            raise AssertionError("Expected OverflowError")
-        except OverflowError:
-            self.assertEqual(
-                self.n5.read_ndarray([2, 2, 2], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
-        # Test writing invalid type block
-        try:
-            self.n5.write_block([2, 2, 2], self.wrong_dtype)
-            raise AssertionError("Expected TypeError")
-        except TypeError:
-            self.assertEqual(
-                self.n5.read_ndarray([4, 4, 4], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
+        super().setUp()
 
 
-class TestI32(unittest.TestCase):
+class TestI32(BaseTestCase.BaseTest):
     def setUp(self):
-        self.root = "test.n5"
         self.dtype = "INT32"
-        self.dataset = "test_{}".format(self.dtype)
-        self.dataset_size = [10, 10, 10]
-        self.block_size = [2, 2, 2]
-
-        pyn5.create_dataset(
-            self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
-        )
-        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 31
-        self.working_block = [
+        self.valid_block = [
             1 - big,
             2 - big,
             3 - big,
@@ -398,7 +177,7 @@ class TestI32(unittest.TestCase):
             big - 2,
             big - 1,
         ]
-        self.out_of_bounds_block = [
+        self.overflow_block = [
             -big,
             -1 - big,
             -2 - big,
@@ -408,59 +187,17 @@ class TestI32(unittest.TestCase):
             big + 2,
             big + 3,
         ]
-        self.wrong_dtype = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        self.wrong_dtype_block = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
 
-    def tearDown(self):
-        if Path(self.root, self.dataset).is_dir():
-            shutil.rmtree(Path(self.root, self.dataset))
-
-    def test_read_write(self):
-        # Dataset should start empty
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.dataset_size),
-            [0] * np.prod(self.dataset_size),
-        )
-        # Test writing a valid block
-        self.n5.write_block([0, 0, 0], self.working_block)
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.block_size), self.working_block
-        )
-
-        # Test writing overflow block
-        try:
-            self.n5.write_block([1, 1, 1], self.out_of_bounds_block)
-            raise AssertionError("Expected OverflowError")
-        except OverflowError:
-            self.assertEqual(
-                self.n5.read_ndarray([2, 2, 2], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
-        # Test writing invalid type block
-        try:
-            self.n5.write_block([2, 2, 2], self.wrong_dtype)
-            raise AssertionError("Expected TypeError")
-        except TypeError:
-            self.assertEqual(
-                self.n5.read_ndarray([4, 4, 4], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
+        super().setUp()
 
 
-class TestI64(unittest.TestCase):
+class TestI64(BaseTestCase.BaseTest):
     def setUp(self):
-        self.root = "test.n5"
         self.dtype = "INT64"
-        self.dataset = "test_{}".format(self.dtype)
-        self.dataset_size = [10, 10, 10]
-        self.block_size = [2, 2, 2]
-
-        pyn5.create_dataset(
-            self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
-        )
-        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
 
         big = 2 ** 63
-        self.working_block = [
+        self.valid_block = [
             1 - big,
             2 - big,
             3 - big,
@@ -470,7 +207,7 @@ class TestI64(unittest.TestCase):
             big - 2,
             big - 1,
         ]
-        self.out_of_bounds_block = [
+        self.overflow_block = [
             -big,
             -1 - big,
             -2 - big,
@@ -480,58 +217,16 @@ class TestI64(unittest.TestCase):
             big + 2,
             big + 3,
         ]
-        self.wrong_dtype = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        self.wrong_dtype_block = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
 
-    def tearDown(self):
-        if Path(self.root, self.dataset).is_dir():
-            shutil.rmtree(Path(self.root, self.dataset))
-
-    def test_read_write(self):
-        # Dataset should start empty
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.dataset_size),
-            [0] * np.prod(self.dataset_size),
-        )
-        # Test writing a valid block
-        self.n5.write_block([0, 0, 0], self.working_block)
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.block_size), self.working_block
-        )
-
-        # Test writing overflow block
-        try:
-            self.n5.write_block([1, 1, 1], self.out_of_bounds_block)
-            raise AssertionError("Expected OverflowError")
-        except OverflowError:
-            self.assertEqual(
-                self.n5.read_ndarray([2, 2, 2], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
-        # Test writing invalid type block
-        try:
-            self.n5.write_block([2, 2, 2], self.wrong_dtype)
-            raise AssertionError("Expected TypeError")
-        except TypeError:
-            self.assertEqual(
-                self.n5.read_ndarray([4, 4, 4], self.block_size),
-                [0] * np.prod(self.block_size),
-            )
+        super().setUp()
 
 
-class TestF32(unittest.TestCase):
+class TestF32(BaseTestCase.BaseTest):
     def setUp(self):
-        self.root = "test.n5"
         self.dtype = "FLOAT32"
-        self.dataset = "test_{}".format(self.dtype)
-        self.dataset_size = [10, 10, 10]
-        self.block_size = [2, 2, 2]
 
-        pyn5.create_dataset(
-            self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
-        )
-        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
-
-        self.working_block = [
+        self.valid_block = [
             -3.3999999521443642e38,
             -1.199999978106707e-38,
             1.199999978106707e-38,
@@ -543,7 +238,7 @@ class TestF32(unittest.TestCase):
         ]
 
         big = 1.5e40
-        self.out_of_bounds_block = [
+        self.overflow_block = [
             -big,
             -1 - big,
             -2 - big,
@@ -553,42 +248,19 @@ class TestF32(unittest.TestCase):
             big + 2,
             big + 3,
         ]
-        self.wrong_dtype = [1, 2, 3, 4, 5, 6, 7, 8]
+        self.wrong_dtype_block = [1, 2, 3, 4, 5, 6, 7, 8]
 
-    def tearDown(self):
-        if Path(self.root, self.dataset).is_dir():
-            shutil.rmtree(Path(self.root, self.dataset))
-
-    def test_read_write_valid(self):
-        # Dataset should start empty
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.dataset_size),
-            [0] * np.prod(self.dataset_size),
-        )
-        # Test writing a valid block
-        self.n5.write_block([0, 0, 0], list(self.working_block))
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.block_size), self.working_block
-        )
+        super().setUp()
 
     def test_read_write_expected_failures(self):
         self.fail("Not yet implemented")
 
 
-class TestF64(unittest.TestCase):
+class TestF64(BaseTestCase.BaseTest):
     def setUp(self):
-        self.root = "test.n5"
         self.dtype = "FLOAT64"
-        self.dataset = "test_{}".format(self.dtype)
-        self.dataset_size = [10, 10, 10]
-        self.block_size = [2, 2, 2]
 
-        pyn5.create_dataset(
-            self.root, self.dataset, self.dataset_size, self.block_size, self.dtype
-        )
-        self.n5 = pyn5.open(self.root, self.dataset, self.dtype, False)
-
-        self.working_block = [
+        self.valid_block = [
             -2.3e-308,
             -1.7e308,
             1.7e308,
@@ -600,7 +272,7 @@ class TestF64(unittest.TestCase):
         ]
 
         big = 1.5e600
-        self.out_of_bounds_block = [
+        self.overflow_block = [
             -big,
             -1 - big,
             -2 - big,
@@ -610,23 +282,9 @@ class TestF64(unittest.TestCase):
             big + 2,
             big + 3,
         ]
-        self.wrong_dtype = [1, 2, 3, 4, 5, 6, 7, 8]
+        self.wrong_dtype_block = [1, 2, 3, 4, 5, 6, 7, 8]
 
-    def tearDown(self):
-        if Path(self.root, self.dataset).is_dir():
-            shutil.rmtree(Path(self.root, self.dataset))
-
-    def test_read_write(self):
-        # Dataset should start empty
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.dataset_size),
-            [0] * np.prod(self.dataset_size),
-        )
-        # Test writing a valid block
-        self.n5.write_block([0, 0, 0], self.working_block)
-        self.assertEqual(
-            self.n5.read_ndarray([0, 0, 0], self.block_size), self.working_block
-        )
+        super().setUp()
 
     def test_read_write_expected_failures(self):
         self.fail("Not yet implemented")

--- a/tests/test.py
+++ b/tests/test.py
@@ -29,21 +29,33 @@ class BaseTestCase:
                 self.n5.read_ndarray([0, 0, 0], self.block_size), self.valid_block
             )
 
-        @unittest.expectedFailure
         def test_read_write_overflow(self):
             """
             Doesn't work properly for float types since floats that are too
             large get converted to inf
             """
-            self.n5.write_block([1, 1, 1], self.overflow_block)
+            try:
+                self.n5.write_block([1, 1, 1], self.overflow_block)
+                raise AssertionError("Expected OverflowError")
+            except OverflowError:
+                self.assertEqual(
+                    self.n5.read_ndarray([2, 2, 2], self.block_size),
+                    [0] * np.prod(self.block_size),
+                )
 
-        @unittest.expectedFailure
         def test_read_write_wrong_dtype(self):
             """
             Doesn't work properly for float types since I'm guessing ints
             get converted to float types somewhere between python and rust
             """
-            self.n5.write_block([2, 2, 2], self.wrong_dtype_block)
+            try:
+                self.n5.write_block([2, 2, 2], self.wrong_dtype_block)
+                raise AssertionError("Expected TypeError")
+            except TypeError:
+                self.assertEqual(
+                    self.n5.read_ndarray([4, 4, 4], self.block_size),
+                    [0] * np.prod(self.block_size),
+                )
 
 
 class TestU8(BaseTestCase.BaseTest):
@@ -252,24 +264,12 @@ class TestF32(BaseTestCase.BaseTest):
 
         super().setUp()
 
-    def test_read_write_expected_failures(self):
-        self.fail("Not yet implemented")
-
 
 class TestF64(BaseTestCase.BaseTest):
     def setUp(self):
         self.dtype = "FLOAT64"
 
-        self.valid_block = [
-            -2.3e-308,
-            -1.7e308,
-            1.7e308,
-            2.3e-308,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-        ]
+        self.valid_block = [-2.3e-308, -1.7e308, 1.7e308, 2.3e-308, 0.0, 0.0, 0.0, 0.0]
 
         big = 1.5e600
         self.overflow_block = [
@@ -285,6 +285,3 @@ class TestF64(BaseTestCase.BaseTest):
         self.wrong_dtype_block = [1, 2, 3, 4, 5, 6, 7, 8]
 
         super().setUp()
-
-    def test_read_write_expected_failures(self):
-        self.fail("Not yet implemented")

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,7 +7,7 @@ import pyn5
 
 
 class BaseTestCase:
-    class IntBaseTest(unittest.TestCase):
+    class BaseTest(unittest.TestCase):
         def setUp(self):
             self.root = "test.n5"
             self.dataset = "test_{}".format(self.dtype)


### PR DESCRIPTION
Each datatype has its own Dataset struct to preserve common 
user interface.
Tests for f32, f64 fail since their failure cases have not yet been
tested