### PR TITLE
Added a python wrapper around read and write

### DIFF
--- a/pyn5/__init__.py
+++ b/pyn5/__init__.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 import logging
+from typing import Tuple
+import numpy as np
 
 from .libpyn5 import (
     DatasetUINT8,
@@ -79,4 +81,87 @@ def open(root_path: str, dataset: str, dtype: str = "", read_only=True):
                 ),
             )
         )
+
+
+def read(dataset, bounds: Tuple[np.ndarray, np.ndarray], dtype: type = int):
+    """
+    Temporary hacky method until dataset.read_ndarray returns np.ndarray
+
+    Note: passing in dtype is necessary since numpy arrays are float by default.
+          dataset.get_data_type() could be implemented, but a better solution would
+          be to have dataset.read_ndarray return a numpy array. 
+    """
+    bounds = (bounds[0].astype(int), bounds[1].astype(int))
+    return (
+        np.array(dataset.read_ndarray(list(bounds[0]), list(bounds[1] - bounds[0])))
+        .reshape(list(bounds[1] - bounds[0]))
+        .transpose([2, 1, 0])
+        .astype(dtype)
+    )
+
+
+def write(
+    dataset,
+    input_bounds: Tuple[np.ndarray, np.ndarray],
+    input_data: np.ndarray,
+    dtype=int,
+):
+    """
+    Temporary hacky method until dataset.write_ndarray is implemented in rust-n5
+    and the PyO3 wrapper
+    """
+    input_data = input_data.astype(dtype)
+    input_bounds = (input_bounds[0].astype(int), input_bounds[1].astype(int))
+    start_block_index = input_bounds[0] // dataset.block_shape
+    stop_block_index = (
+        input_bounds[1] + dataset.block_shape - 1
+    ) // dataset.block_shape
+    for i in range(start_block_index[0], stop_block_index[0]):
+        for j in range(start_block_index[1], stop_block_index[1]):
+            for k in range(start_block_index[2], stop_block_index[2]):
+                block_index = np.array([i, j, k], dtype=int)
+                block_bounds = (
+                    block_index * dataset.block_shape,
+                    (block_index + 1) * dataset.block_shape,
+                )
+
+                if all(block_bounds[0] >= input_bounds[0]) and all(
+                    block_bounds[1] <= input_bounds[1]
+                ):
+                    # Overwrite block data entirely
+                    block_data = input_data[
+                        list(
+                            map(
+                                slice,
+                                block_bounds[0] - input_bounds[0],
+                                block_bounds[1] - input_bounds[0],
+                            )
+                        )
+                    ]
+                else:
+                    block_data = read(dataset, block_bounds, dtype)
+
+                    intersection_bounds = (
+                        np.maximum(block_bounds[0], input_bounds[0]),
+                        np.minimum(block_bounds[1], input_bounds[1]),
+                    )
+                    relative_block_bounds = list(
+                        map(
+                            slice,
+                            intersection_bounds[0] - block_bounds[0],
+                            intersection_bounds[1] - block_bounds[0],
+                        )
+                    )
+                    relative_data_bounds = list(
+                        map(
+                            slice,
+                            intersection_bounds[0] - input_bounds[0],
+                            intersection_bounds[1] - input_bounds[0],
+                        )
+                    )
+                    block_data[relative_block_bounds] = input_data[relative_data_bounds]
+
+                dataset.write_block(
+                    block_index, block_data.transpose([2, 1, 0]).flatten()
+                )
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,11 @@ macro_rules! dataset {
                 }))
             }
 
+            #[getter]
+            fn block_shape(&self) -> PyResult<(Vec<i32>)> {
+                Ok(self.attr.get_block_size().iter().cloned().collect())
+            }
+
             fn read_ndarray(
                 &self,
                 translation: Vec<i64>,


### PR DESCRIPTION
Provides better support for reading and writting numpy arrays to n5
files. This is just a temporary solution until numpy support is added
to the rust side