### PR TITLE
Add liniting to the tests

### DIFF
--- a/pyn5/__init__.py
+++ b/pyn5/__init__.py
@@ -6,4 +6,34 @@ __author__ = """William Hunter Patton"""
 __email__ = "pattonw@hhmi.org"
 __version__ = "0.1.0"
 
-from .python_wrappers import *
+from .python_wrappers import open, read, write
+from .pyn5 import (
+    DatasetUINT8,
+    DatasetUINT16,
+    DatasetUINT32,
+    DatasetUINT64,
+    DatasetINT8,
+    DatasetINT16,
+    DatasetINT32,
+    DatasetINT64,
+    DatasetFLOAT32,
+    DatasetFLOAT64,
+    create_dataset,
+)
+
+__all__ = [
+    "open",
+    "read",
+    "write",
+    "create_dataset",
+    "DatasetUINT8",
+    "DatasetUINT16",
+    "DatasetUINT32",
+    "DatasetUINT64",
+    "DatasetINT8",
+    "DatasetINT16",
+    "DatasetINT32",
+    "DatasetINT64",
+    "DatasetFLOAT32",
+    "DatasetFLOAT64",
+]

--- a/pyn5/python_wrappers.py
+++ b/pyn5/python_wrappers.py
@@ -18,7 +18,6 @@ from .pyn5 import (
     DatasetINT64,
     DatasetFLOAT32,
     DatasetFLOAT64,
-    create_dataset,
 )
 
 
@@ -92,7 +91,7 @@ def read(dataset, bounds: Tuple[np.ndarray, np.ndarray], dtype: type = int):
 
     Note: passing in dtype is necessary since numpy arrays are float by default.
           dataset.get_data_type() could be implemented, but a better solution would
-          be to have dataset.read_ndarray return a numpy array. 
+          be to have dataset.read_ndarray return a numpy array.
     """
     bounds = (bounds[0].astype(int), bounds[1].astype(int))
     return (

--- a/tests/test_pyn5.py
+++ b/tests/test_pyn5.py
@@ -374,4 +374,3 @@ class TestPythonReadWrite(unittest.TestCase):
                 np.array(range(64), dtype=int).reshape([4, 4, 4]),
             )
         )
-

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,7 @@ setenv =
 deps =
     -r{toxinidir}/requirements_dev.txt
 
-commands = python setup.py test
+commands = 
+    python setup.py test
+    flake8 pyn5 tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,8 @@ python =
     3.6: py36
     3.5: py35
 
-[testenv:flake8]
-basepython = python
-deps = flake8
-commands = flake8 pyn5
+[flake8]
+max-line-length = 98
 
 [testenv]
 usedevelop = 


### PR DESCRIPTION
flake8 the pyn5 and the tests directories.
Made imports in __init__.py explicit to satisfy linting demands.
cleaned up some white-space.