### PR TITLE
python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,17 @@ jobs:
       python: 3.5
     - <<: *test_template
       python: 3.6
+    - <<: *test_template
+      python: 3.7
+      dist: xenial
+      sudo: required
     - <<: *deploy_template
       env:
         - CIBW_BUILD=cp35-*
     - <<: *deploy_template
       env:
         - CIBW_BUILD=cp36-*
+    - <<: *deploy_template
+      env:
+        - CIBW_BUILD=cp37-*
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py35, py36
+envlist = py35, py36, py37
 
 [travis]
 python =
+    3.7: py37
     3.6: py36
     3.5: py35
 


### PR DESCRIPTION
add support for python 3.7 in the testing and building stages.
Using distribution xenial is the official workaround for getting python
3.7 on travis.