### PR TITLE
Add a job for deploying source distribution.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+language: python
+python:
+  - 3.5
+
 stages:
   - test
   - deploy
@@ -9,8 +13,6 @@ env:
 
 test_template: &test_template
   stage: test
-  language: python
-  python: 3.6
   before_install:
     source ./ci/travis/setup_rust.sh
   install:
@@ -20,13 +22,11 @@ test_template: &test_template
 
 deploy_template: &deploy_template
   stage: deploy
-  language: python
   sudo: required
   services:
     docker
   env:
     - CIBW_BUILD=cp35-*
-  python: 3.6
   install:
     pip install -U cibuildwheel
   script:
@@ -52,4 +52,15 @@ jobs:
     - <<: *deploy_template
       env:
         - CIBW_BUILD=cp37-*
+    - stage: deploy
+      script:
+        echo "skip"
+      deploy:
+        on:
+          tags: true
+        distributions: sdist
+        password:
+          secure: VeZNGpUs5ne3ZlCeZLPbT+3O6yRDM9sv8emg6m90ZwLuZAlXV0t2dGHKccMTBMbS2jWSy2q4TY2IkN0SOWrOmi53Klt3K5Y461Ra8dT+XdmXK8g+36HJEJKWfFvVpYVuIw72yoUWHZsr2iNxi7tiAc/AjBvbnbgSXuAayuVm+8K7tQ85kkfbdBErDQnhziEiqtIrjak3hwBgjWpm0UEuAKG/eTBFk0BAN9wqRajCS58WLaLVnF4FtAHT4QAxo33j99njB7cz8PLjXNd3BxT2BpMbjqmg8krVW7ayMJKdLvWdICezPB4nlsnL9jBlXMaRvI0ijSl59QkVCDbkrERUCR7IdJZqAX3IFSe+9X1cwzJsJeXYOfQjYMX+ZyqR8qcmQKS6M1u3uYMXhoj+TU9uO0sK4dNxrS0DRhg22TdjAcpqnz0UDVVWfFapltroE0ePVPs8aOOqdpJewRDPDI0ghRg/nzrSIhEI+85XnSTcjm4if5hwiEFchIFlV5d/ZIHtPn+b0fCRTDMq4kjObxD9uBbVvda1+CESCNrE91oB1erlrjygsDnpdRWi5dzaOVe5DJmAxT/V5mPFlskOPJLZr3lzZOQm1FGVJbvTN766plDCWozTAG8wT58hq/nJTBIiRjHlQnhFjlHLkaWTEq/jJ8mA++KXvbofCy833V0OMrw=
+        provider: pypi
+        user: pattonw
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,6 @@ recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
+
+include Cargo.toml
+recursive-include src *


### PR DESCRIPTION
Include rust code in the MANIFEST.in file, and add a deploy job in the
deploy stage of travis.yml.

addresses issues in https://github.com/pattonw/rust-pyn5/issues/25.

Working but unpollished. Using the deploy key is inconsistent
with other jobs. I would prefer to move sdist deployment into a script.
Also providing the encrypted password in deploy is redundant since
a repository wide secure password has been added for the
cibuildwheels step.



