### PR TITLE
Fixed read wrapper

### DIFF
--- a/pyn5/python_wrappers.py
+++ b/pyn5/python_wrappers.py
@@ -96,7 +96,7 @@ def read(dataset, bounds: Tuple[np.ndarray, np.ndarray], dtype: type = int):
     bounds = (bounds[0].astype(int), bounds[1].astype(int))
     return (
         np.array(dataset.read_ndarray(list(bounds[0]), list(bounds[1] - bounds[0])))
-        .reshape(list(bounds[1] - bounds[0]))
+        .reshape(list(bounds[1] - bounds[0])[::-1])
         .transpose([2, 1, 0])
         .astype(dtype)
     )

--- a/tests/test_pyn5.py
+++ b/tests/test_pyn5.py
@@ -374,3 +374,10 @@ class TestPythonReadWrite(unittest.TestCase):
                 np.array(range(64), dtype=int).reshape([4, 4, 4]),
             )
         )
+
+        # test writing data in non block shapes
+        bounds = (np.array([0, 0, 0]), np.array([1, 2, 3]))
+        data = np.array(range(6)).reshape([1, 2, 3])
+        pyn5.write(self.n5, bounds, data)
+
+        self.assertTrue(np.array_equal(pyn5.read(self.n5, bounds), data))


### PR DESCRIPTION
read returned unexpected results when queried bounding box was non
square.

I added a test and fixed the bug.