### PR TITLE
Doc'n'dtype

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -58,6 +58,8 @@ Get Started!
 ------------
 
 Ready to contribute? Here's how to set up `pyn5` for local development.
+This assumes you have the rust nightly toolchain installed
+(see https://www.rust-lang.org/tools/install ).
 
 1. Fork the `pyn5` repo on GitHub.
 2. Clone your fork locally::
@@ -68,6 +70,7 @@ Ready to contribute? Here's how to set up `pyn5` for local development.
 
     $ mkvirtualenv pyn5
     $ cd pyn5/
+    $ pip install -r requirements_dev.txt
     $ python setup.py develop
 
 4. Create a branch for local development::
@@ -102,7 +105,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6, and for PyPy. Check
+3. The pull request should work for Python 3.5, 3.6, and 3.7. Check
    https://travis-ci.org/pattonw/pyn5/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Python wrapper around rust-n5.
 
 
 * Free software: MIT license
-* Documentation: https://pyn5.readthedocs.io.
+* Documentation: https://rust-pyn5.readthedocs.io.
 
 
 Features

--- a/pyn5/python_wrappers.py
+++ b/pyn5/python_wrappers.py
@@ -21,6 +21,20 @@ from .pyn5 import (
 )
 
 
+dataset_types = {
+    np.dtype("uint8"): DatasetUINT8,
+    np.dtype("uint16"): DatasetUINT16,
+    np.dtype("uint32"): DatasetUINT32,
+    np.dtype("uint64"): DatasetUINT64,
+    np.dtype("int8"): DatasetINT8,
+    np.dtype("int16"): DatasetINT16,
+    np.dtype("int32"): DatasetINT32,
+    np.dtype("int64"): DatasetINT64,
+    np.dtype("float32"): DatasetFLOAT32,
+    np.dtype("float64"): DatasetFLOAT64,
+}
+
+
 def open(root_path: str, dataset: str, dtype: str = "", read_only=True):
     """
     Returns a Dataset of the corresponding dtype. Leave dtype blank to return
@@ -45,44 +59,23 @@ def open(root_path: str, dataset: str, dtype: str = "", read_only=True):
                     )
                 )
 
-    if dtype == "UINT8":
-        return DatasetUINT8(root_path, dataset, read_only)
-    elif dtype == "UINT16":
-        return DatasetUINT16(root_path, dataset, read_only)
-    elif dtype == "UINT32":
-        return DatasetUINT32(root_path, dataset, read_only)
-    elif dtype == "UINT64":
-        return DatasetUINT64(root_path, dataset, read_only)
-    elif dtype == "INT8":
-        return DatasetINT8(root_path, dataset, read_only)
-    elif dtype == "INT16":
-        return DatasetINT16(root_path, dataset, read_only)
-    elif dtype == "INT32":
-        return DatasetINT32(root_path, dataset, read_only)
-    elif dtype == "INT64":
-        return DatasetINT64(root_path, dataset, read_only)
-    elif dtype == "FLOAT32":
-        return DatasetFLOAT32(root_path, dataset, read_only)
-    elif dtype == "FLOAT64":
-        return DatasetFLOAT64(root_path, dataset, read_only)
-    else:
-        raise ValueError(
-            "Given dtype {} is not supported. Please choose from ({})".format(
-                dtype,
-                (
-                    "UINT8",
-                    "UINT16",
-                    "UINT32",
-                    "UINT64",
-                    "INT8",
-                    "INT16",
-                    "INT32",
-                    "INT64",
-                    "FLOAT32",
-                    "FLOAT64",
-                ),
-            )
-        )
+    unsupported_dtype_msg = "Given dtype {} is not supported. Please choose from ({})".format(
+        dtype,
+        tuple(dataset_types),
+    )
+
+    if not dtype:
+        raise ValueError(unsupported_dtype_msg)
+    if isinstance(dtype, str):
+        dtype = dtype.lower()
+
+    dtype = np.dtype(dtype)
+
+    try:
+        dataset_type = dataset_types[dtype]
+        return dataset_type(root_path, dataset, read_only)
+    except KeyError:
+        raise ValueError(unsupported_dtype_msg)
 
 
 def read(dataset, bounds: Tuple[np.ndarray, np.ndarray], dtype: type = int):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,5 +9,3 @@ twine==1.13.0
 Sphinx==2.1.1
 setuptools_rust==0.10.6
 numpy==1.16.4
-
-


### PR DESCRIPTION
A couple of minor changes to the documentation, possibly had some hangovers from the cookiecutter template left in there. Also, I think the dependency bot sticks an extra newline onto the end of the requirements file every time it changes something :-1: 

Also made the wrapper `open` happy using any dtype specifier which numpy is compatible with, plus the existing all-upper string.