### PR TITLE
H5pylike 0.6

### DIFF
--- a/pyn5/attributes.py
+++ b/pyn5/attributes.py
@@ -20,6 +20,10 @@ class NumpyEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, np.ndarray):
             return obj.tolist()
+        if isinstance(obj, np.integer):
+            return int(obj)
+        if isinstance(obj, np.floating):
+            return float(obj)
         return super().default(obj)
 
 
@@ -59,14 +63,14 @@ class AttributeManager(AttributeManagerBase):
         super().__init__(mode)
 
     @classmethod
-    def from_parent(cls, parent: H5ObjectLike) -> "AttributeManager":
+    def from_container(cls, container: H5ObjectLike) -> "AttributeManager":
         """
         Create AttributeManager for a File, Group or Dataset.
 
-        :param parent: File, Group or Dataset to which the attributes belong.
+        :param container: File, Group or Dataset to which the attributes belong.
         :return: AttributeManager instance
         """
-        return cls(parent._path, parent.mode)
+        return cls(container._path, container.mode)
 
     @restrict_metadata
     def __setitem__(self, k, v) -> None:

--- a/pyn5/dataset.py
+++ b/pyn5/dataset.py
@@ -4,7 +4,7 @@ from typing import Union, Tuple, Optional, Any
 
 import numpy as np
 
-from h5py_like import DatasetBase, AttributeManagerBase, mutation, Name
+from h5py_like import DatasetBase, AttributeManagerBase, mutation
 from h5py_like.shape_utils import thread_read_fn, thread_write_fn
 from pyn5.attributes import AttributeManager
 from .pyn5 import (
@@ -38,17 +38,15 @@ dataset_types = {
 class Dataset(DatasetBase):
     threads = None
 
-    def __init__(self, name: str, parent: "Group"):  # noqa would need circular imports
+    def __init__(self, basename: str, parent: "Group"):  # noqa would need circular imports
         """
 
-        :param name: basename of the dataset
+        :param basename: basename of the dataset
         :param parent: group to which the dataset belongs
         """
-        super().__init__(parent.mode)
-        self._name = name
-        self._parent = parent
-        self._path = self.parent._path / name
-        self._attrs = AttributeManager.from_parent(self)
+        super().__init__(basename, parent)
+        self._path = self.parent._path / self.basename
+        self._attrs = AttributeManager.from_container(self)
         self.threads = copy(self.threads)
 
         attrs = self._attrs._read_attributes()
@@ -141,11 +139,3 @@ class Dataset(DatasetBase):
     @property
     def attrs(self) -> AttributeManagerBase:
         return self._attrs
-
-    @property
-    def name(self) -> str:
-        return str(Name(self.parent.name) / self._name)
-
-    @property
-    def parent(self):
-        return self._parent

--- a/pyn5/file_group.py
+++ b/pyn5/file_group.py
@@ -22,18 +22,16 @@ N5_VERSION_INFO = tuple(int(i) for i in N5_VERSION.split('.'))
 
 
 class Group(GroupBase):
-    def __init__(self, name: str, parent: "Group"):
+    def __init__(self, basename: str, parent: "Group"):
         """
 
-        :param name: basename of the group
+        :param basename: basename of the group
         :param parent: group to which the group belongs
         """
-        self._name = name
-        self._parent = parent
-        self._path = self.parent._path / name
+        super().__init__(basename, parent)
+        self._path = self.parent._path / self.basename
 
-        self._attrs = AttributeManager.from_parent(self)
-        super().__init__(self.mode)
+        self._attrs = AttributeManager.from_container(self)
 
     def _create_child_group(self, name) -> GroupBase:
         dpath = self._path / name
@@ -154,14 +152,6 @@ class Group(GroupBase):
     def attrs(self) -> AttributeManager:
         return self._attrs
 
-    @property
-    def name(self) -> str:
-        return str(Name(self.parent.name) / self._name)
-
-    @property
-    def parent(self):
-        return self._parent
-
     @mutation
     def __delitem__(self, v) -> None:
         shutil.rmtree(self[v]._path)
@@ -180,8 +170,9 @@ class File(FileMixin, Group):
         super().__init__(name, mode)
         self._require_dir(self.filename)
         self._path = self.filename
-        self._attrs = AttributeManager.from_parent(self)
+        self._attrs = AttributeManager.from_container(self)
 
+    @mutation
     def __setitem__(self, name, obj):
         """Not implemented"""
         raise NotImplementedError()

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,5 +11,5 @@ setuptools_rust==0.10.6
 numpy==1.16.4
 pytest==4.6.3
 pytest-runner==5.1
-h5py_like==0.5.2
+h5py_like>=0.6.0
 h5py==2.9.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = ["numpy", "h5py_like>=0.5.2"]
+requirements = ["numpy", "h5py_like>=0.6.0"]
 
 setup_requirements = []
 test_requirements = []


### PR DESCRIPTION
- refactored constructors (only used internally) to better reflect common usage
  - group and dataset do not look after their own R/W mode any more 
- default JSON serialiser handles more numpy dtypes
- less ambiguous naming around parents and names